### PR TITLE
Add JSON Config File Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Which will generate __HTML__ files for the __Sherlock-Holmes-Selected-Stories di
 
 **NOTE:** HTML files markdown syntax will be bold
 
+`node my-button.js -c ssg-config.json` Will read the input and language options from the specified config file.
+
 # Options
 Options:
 
@@ -31,6 +33,8 @@ Options:
  ` -v, --version  Show version number                                   [boolean]`
 
  ` -i, --input    convert .txt file to html file              [string] [required]`
+ 
+ ` -c, --config   specify path to config file with options               [string]`
  
  # Test Site
  https://my-button-ssg.vercel.app/ 

--- a/my-button.js
+++ b/my-button.js
@@ -56,7 +56,7 @@ fs.mkdir("./dist", err=>{
 let tempHtml;
 let footer = '© 2022 OSD600 Seneca';
 let fileType ='';
-let lang;
+let lang = argv.lang;
 let inputPath = argv.input;
 let configFilePath = argv.config;
 
@@ -87,7 +87,7 @@ if(argv.lang == '.'){
   lang = argv.lang;
 }
 
-let stats = fs.statSync(inputPath, argv.lang);
+let stats = fs.statSync(inputPath, lang);
 
 if(stats.isDirectory()){
   fs.readdirSync(inputPath).forEach(file =>{

--- a/my-button.js
+++ b/my-button.js
@@ -81,7 +81,7 @@ if (configFilePath) {
   }
 }
 
-if (lang == '.') {
+if (lang == '.' || lang == undefined) {
   lang = "en-CA";
 }
 

--- a/my-button.js
+++ b/my-button.js
@@ -69,8 +69,8 @@ if (configFilePath) {
   try {
     let configFileData = fs.readFileSync(configFilePath);
     let configOptions = JSON.parse(configFileData);
-    console.log(configOptions);
-    return;
+    inputPath = configOptions.input;
+    lang = configOptions.lang;
   } catch (parseError) {
     if (parseError instanceof SyntaxError) {
       console.error("Invalid JSON");
@@ -81,10 +81,8 @@ if (configFilePath) {
   }
 }
 
-if(argv.lang == '.'){
+if (lang == '.') {
   lang = "en-CA";
-}else{
-  lang = argv.lang;
 }
 
 let stats = fs.statSync(inputPath, lang);

--- a/my-button.js
+++ b/my-button.js
@@ -53,7 +53,6 @@ fs.mkdir("./dist", err=>{
 
 //Define variables
 //let stats = fs.statSync(argv.input);
-let stats = fs.statSync(argv.input, argv.lang);
 let tempHtml;
 let footer = '© 2022 OSD600 Seneca';
 let fileType ='';
@@ -87,6 +86,7 @@ if(argv.lang == '.'){
   lang = argv.lang;
 }
 
+let stats = fs.statSync(argv.input, argv.lang);
 
 if(stats.isDirectory()){
   fs.readdirSync(argv.input).forEach(file =>{

--- a/my-button.js
+++ b/my-button.js
@@ -28,6 +28,12 @@ let argv = require('yargs/yargs')(process.argv.slice(2))
     default: '.',
     describe: 'generate the lang attribute',
     type: 'string'
+  },
+  config: {
+    alias: 'c',
+    demandOption: false,
+    describe: 'specify path to config file with options',
+    type: 'string'
   }
 })
 .argv;
@@ -52,6 +58,28 @@ let tempHtml;
 let footer = '© 2022 OSD600 Seneca';
 let fileType ='';
 let lang;
+let configFilePath = argv.config;
+
+if (configFilePath) {
+  if (fs.existsSync(configFilePath) == false || fs.statSync(configFilePath).isDirectory()) {
+    console.error("Invalid config file path");
+    return;
+  }
+
+  try {
+    let configFileData = fs.readFileSync(configFilePath);
+    let configOptions = JSON.parse(configFileData);
+    console.log(configOptions);
+    return;
+  } catch (parseError) {
+    if (parseError instanceof SyntaxError) {
+      console.error("Invalid JSON");
+      return;
+    }
+
+    console.error(`Error while parsing config file: ${parseError}`);
+  }
+}
 
 if(argv.lang == '.'){
   lang = "en-CA";

--- a/my-button.js
+++ b/my-button.js
@@ -57,6 +57,7 @@ let tempHtml;
 let footer = '© 2022 OSD600 Seneca';
 let fileType ='';
 let lang;
+let inputPath = argv.input;
 let configFilePath = argv.config;
 
 if (configFilePath) {
@@ -86,10 +87,10 @@ if(argv.lang == '.'){
   lang = argv.lang;
 }
 
-let stats = fs.statSync(argv.input, argv.lang);
+let stats = fs.statSync(inputPath, argv.lang);
 
 if(stats.isDirectory()){
-  fs.readdirSync(argv.input).forEach(file =>{
+  fs.readdirSync(inputPath).forEach(file =>{
   
     //Display all the files in the directory
     console.log("File name: ", file);
@@ -97,7 +98,7 @@ if(stats.isDirectory()){
 
     //Only convert the .txt file into a HTML file
     if(fileType === 'txt' || fileType === 'md'){
-    fs.readFile(argv.input + "/"+ file.toString(), 'utf-8', function(err, fullText){
+    fs.readFile(inputPath + "/"+ file.toString(), 'utf-8', function(err, fullText){
       if(err) return console.log(err);
       let fname = path.parse(file).name;
       //name the file without space
@@ -162,15 +163,15 @@ if(stats.isDirectory()){
 }
 
 else{
-  fileType = argv.input.split('.').pop(); 
+  fileType = inputPath.split('.').pop(); 
   //console.log(fileType);
 
   //Only convert the .txt and .md file into a HTML file
   if(fileType === 'txt' || fileType === 'md'){
-  fs.readFile(argv.input, 'utf8', function(err, fullText){
+  fs.readFile(inputPath, 'utf8', function(err, fullText){
       if(err) return console.log(err);
 
-      let fname = argv.input.split(".");
+      let fname = inputPath.split(".");
       //console.log(fname) //[ 'Silver Blaze', 'txt' ]
       let validFname = fname[0].split(' ').join('');
       

--- a/my-button.js
+++ b/my-button.js
@@ -85,6 +85,10 @@ if (lang == '.' || lang == undefined) {
   lang = "en-CA";
 }
 
+if (inputPath == undefined) {
+  inputPath = ' ';
+}
+
 let stats = fs.statSync(inputPath, lang);
 
 if(stats.isDirectory()){

--- a/ssg-config.json
+++ b/ssg-config.json
@@ -1,5 +1,5 @@
 {
-  "input": "./Sherlock-Holmes-Selected_stories",
+  "input": "./Sherlock-Holmes-Selected-Stories",
   "lang": "pt",
   "output": "./would-be-ignored",
   "future-feature": "should be ignored for now"

--- a/ssg-config.json
+++ b/ssg-config.json
@@ -1,0 +1,6 @@
+{
+  "input": "./Sherlock-Holmes-Selected_stories",
+  "lang": "pt",
+  "output": "./would-be-ignored",
+  "future-feature": "should be ignored for now"
+}


### PR DESCRIPTION
Resolves #11 

Added support for `-c, --config` flag to specify path to a config file.
The config file can contain the required and optional arguments in JSON format.
This will override any options specified as command line arguments.
Supported options are input path and lang attribute. Any additional arguments will be ignored.